### PR TITLE
Evacuation phase

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -24,7 +24,7 @@ CFLAGS_OPT.release=-O3 -fno-omit-frame-pointer -march=x86-64-v3
 CFLAGS=${CFLAGS_OPT.${BUILD}} ${CSTDFLAGS}
 CFLAGS_TEST=${CFLAGS_OPT.dev} ${CSTDFLAGS}
 
-MEMORY_HEADERS=$(RUNTIME_DIR)common.h $(MEMORY_DIR)allocator.h $(TEST_DIR)test.h
+MEMORY_HEADERS=$(RUNTIME_DIR)common.h $(RUNTIME_DIR)worklist.h  $(MEMORY_DIR)allocator.h $(TEST_DIR)test.h 
 MEMORY_SOURCES=$(MEMORY_DIR)allocator.c $(TEST_DIR)test.c
 MEMORY_OBJS=$(OUT_OBJ)allocator.o $(OUT_OBJ)test.o
 

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -45,6 +45,13 @@ typedef struct Object{
 **/
 #define DEFAULT_ENTRY_SIZE sizeof(Object) 
 
+// Allows us to correctly determine pointer offsets
+#ifdef ALLOC_DEBUG_CANARY
+#define REAL_ENTRY_SIZE(ESIZE) (ALLOC_DEBUG_CANARY_SIZE + ESIZE + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
+#else
+#define REAL_ENTRY_SIZE(ESIZE) (ESIZE + sizeof(MetaData))
+#endif
+
 #ifdef VERBOSE_HEADER
 typedef struct MetaData 
 {

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -51,6 +51,11 @@ typedef struct Object{
 }Object;
 
 #define PAGE_OFFSET(p) (char*)p + sizeof(PageInfo)
+#define OBJECT_AT(page, index) \
+    ((Object*)(PAGE_OFFSET(page) + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + \
+    ((index) * REAL_ENTRY_SIZE((page)->entrysize))))
+#define FREE_LIST_ENTRY_AT(page, index) \
+((FreeListEntry*)(PAGE_OFFSET(page) + (index) * REAL_ENTRY_SIZE((page)->entrysize)))
 
 #ifdef ALLOC_DEBUG_CANARY
 //Gives us the beginning of block (just before canary in case of canaries enabled)
@@ -58,9 +63,12 @@ typedef struct Object{
 
 //Start of our object from the begginning of block (address returned from allocate())
 #define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
+#define META_FROM_FREELIST_ENTRY(f_entry) ((MetaData*)((char*)f_entry + ALLOC_DEBUG_CANARY_SIZE))
 #else
 #define BLOCK_START_FROM_OBJ(obj) ((char*)obj - sizeof(MetaData))
 #define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData))
+#define META_FROM_FREELIST_ENTRY(f_entry) ((MetaData*)f_entry)
+
 #endif
 
 

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -51,9 +51,9 @@ typedef struct MetaData
     bool isalloc;
     bool isyoung;
     bool ismarked;
-
-    uint8_t padding[5]; //ensure at least 8 bytes in size
-} MetaData;
+    bool isroot;
+    uint32_t forward_index;
+} MetaData; // We want meta to be 8 bytes 
 #else
 typedef struct MetaData 
 {

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -29,6 +29,12 @@
             do { } while (0)
 #endif
 
+/* Maximum number of roots on our root stack */
+#define MAX_ROOTS 100
+
+/*Negative offset to find metadata assuming obj is the start of data seg*/
+#define META_FROM_OBJECT(obj) ((MetaData*)((char*)(obj) - sizeof(MetaData)))
+
 /** 
 * Hard defining maximum number of possible children for an obj,
 * I suspect this should not be the case but works for testing.
@@ -43,6 +49,20 @@ typedef struct Object{
     struct Object* children[MAX_CHILDREN];
     uint16_t num_children;
 }Object;
+
+#define PAGE_OFFSET(p) (char*)p + sizeof(PageInfo)
+
+#ifdef ALLOC_DEBUG_CANARY
+//Gives us the beginning of block (just before canary in case of canaries enabled)
+#define BLOCK_START_FROM_OBJ(obj) ((char*)obj - sizeof(MetaData) - ALLOC_DEBUG_CANARY_SIZE)
+
+//Start of our object from the begginning of block (address returned from allocate())
+#define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
+#else
+#define BLOCK_START_FROM_OBJ(obj) ((char*)obj - sizeof(MetaData))
+#define OBJ_START_FROM_BLOCK(obj) ((char*)obj + sizeof(MetaData))
+#endif
+
 
 /** 
 * As this project grows it would be best if we instead predefine multiple

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -76,3 +76,13 @@ typedef struct MetaData
 static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #endif
 
+// After we evacuate an object we need to update the original metadata
+#define RESET_METADATA_FOR_OBJECT(meta)              \
+do {                                                 \
+    (meta)->isalloc = false;                         \
+    (meta)->isyoung = false;                         \
+    (meta)->ismarked = false;                        \
+    (meta)->isroot = false;                          \
+    (meta)->forward_index = MAX_FWD_INDEX;           \
+} while(0)
+

--- a/src/runtime/common.h
+++ b/src/runtime/common.h
@@ -12,6 +12,11 @@
 #define MEM_STATS
 #define VERBOSE_HEADER
 
+#ifdef BSQ_GC_CHECK_ENABLED
+#define ALLOC_DEBUG_MEM_INITIALIZE
+#define ALLOC_DEBUG_CANARY
+#endif
+
 #define BSQ_MEM_ALIGNMENT 8
 
 #define DEBUG
@@ -52,6 +57,8 @@ typedef struct Object{
 #define REAL_ENTRY_SIZE(ESIZE) (ESIZE + sizeof(MetaData))
 #endif
 
+#define MAX_FWD_INDEX UINT32_MAX
+
 #ifdef VERBOSE_HEADER
 typedef struct MetaData 
 {
@@ -66,6 +73,6 @@ typedef struct MetaData
 {
     uint64_t meta; //8 byte bit vector
 } MetaData;
-
 static_assert(sizeof(MetaData) == 8, "MetaData size is not 8 bytes");
 #endif
+

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -1,11 +1,5 @@
 #include "allocator.h"
 
-#ifdef ALLOC_DEBUG_CANARY
-#define REAL_ENTRY_SIZE(ESIZE) (ALLOC_DEBUG_CANARY_SIZE + ESIZE + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE)
-#else
-#define REAL_ENTRY_SIZE(ESIZE) (ESIZE + sizeof(MetaData))
-#endif
-
 #define CANARY_DEBUG_CHECK
 
 size_t root_count = 0;
@@ -158,11 +152,24 @@ static bool is_worklist_empty(Worklist* worklist)
 * to find a given objects parent, if the old child matches, we update to new child
 **/
 void update_parent_pointers(Object* old_obj, Object* new_obj) {
-    
+
 }
 
 void evacuate(Worklist* marked_nodes_list) 
 {
+    /** 
+    * General approach: Iterate through the entire marked_nodes_list. Every non-root object will
+    * be moved to the evacuation pages. For each moved object:
+    * - Update its forward_index to reflect its new location in the evacuation pages.
+    * - The forward_index stores the address (or index) of the moved object.
+    * 
+    * After moving the object, we need to update the parent pointers that reference this object:
+    * - For each parent of this object, we use the forward_index to find the object's new location 
+    *   in the evacuation pages and update the parent's reference (pointer) to the new location.
+    **/
+
+    /* Now an even better question is how to efficiently find the parents of this object... */
+
     while(!is_worklist_empty(marked_nodes_list)) {
         //we will simply memcpy to new evac list
 

--- a/src/runtime/memory/allocator.c
+++ b/src/runtime/memory/allocator.c
@@ -10,7 +10,7 @@ size_t root_count = 0;
 AllocatorBin a_bin = {.freelist = NULL, .entrysize = DEFAULT_ENTRY_SIZE, .page = NULL, .page_manager = NULL};
 PageManager p_mgr = {.all_pages = NULL, .evacuate_page = NULL, .filled_pages = NULL};
 
-/* To be used with updating pointers after moving to evac page */
+/* Forwarding table to be used with updating pointers after moving to evac page */
 Worklist f_table = {.size = 0};
 
 /* Our stack of roots to be marked after allocations finish */
@@ -123,88 +123,29 @@ bool isRoot(void* obj)
     return true; // For now, assume all objects are valid pointers
 }
 
-/* Worklist helpers */
-static void initialize_worklist(Worklist* worklist) 
-{
-    worklist->size = 0;
-}
-
-#if 0
-static Object* worklist_top(Worklist* worklist)
-{
-    assert(worklist->size > 0);
-
-    if(worklist->size > 0) {
-        return worklist->data[worklist->size - 1];
-    } else {
-        return worklist->data[0];
-    }
-}
-#endif
-
-static bool add_to_worklist(Worklist* worklist, Object* obj) 
-{
-    if (worklist->size >= WORKLIST_CAPACITY) {
-        /* Worklist is full */
-        debug_print("Worklist overflow!\n");
-        return false;
-    }
-    worklist->data[worklist->size++] = obj;
-    return true;
-}
-
-static Object* remove_from_worklist(Worklist* worklist) 
-{
-    if (worklist->size == 0) {
-        return NULL;
-    }
-    return worklist->data[--worklist->size]; //prefix decrement crucial here
-}
-
-// I really feel that there are better choices than this
-static Object* remove_oldest_from_worklist(Worklist* worklist) {
-    if (worklist->size == 0) {
-        return NULL;
-    }
-    
-    Object* oldest = worklist->data[0];
-    
-    // Shift all elements to the left
-    for (size_t i = 1; i < worklist->size; i++) {
-        worklist->data[i - 1] = worklist->data[i];
-    }
-    
-    worklist->size--;
-    return oldest;
-}
-
-static bool is_worklist_empty(Worklist* worklist) 
-{
-    return worklist->size == 0;
-}
-
 // Move object to evacuate_page and reset old metadata
 static void* evacuate_object(AllocatorBin *bin, Object* obj, Worklist* forward_table) {
     FreeListEntry* start_of_evac = bin->page_manager->evacuate_page->freelist;
     FreeListEntry* next_evac_freelist_object = start_of_evac->next;
 
     // Direct copy of data from original page to evacuation page
-    void* evac_obj_base = memcpy(start_of_evac, (char*)obj - sizeof(MetaData) - ALLOC_DEBUG_CANARY_SIZE, REAL_ENTRY_SIZE(DEFAULT_ENTRY_SIZE));
+    void* evac_obj_base = memcpy(start_of_evac, BLOCK_START_FROM_OBJ(obj), REAL_ENTRY_SIZE(DEFAULT_ENTRY_SIZE));
 
     //update freelist of evac page, memcpy was destroying pointers in our freelist for evac page so I had to manually store and assign after memcpy
     bin->page_manager->evacuate_page->freelist = next_evac_freelist_object;
 
     debug_print("[DEBUG] Object moved from %p to %p in evac page\n", obj, evac_obj_base);
 
-    Object* evac_obj_data = (Object*)((char*)evac_obj_base + sizeof(MetaData) + ALLOC_DEBUG_CANARY_SIZE);
-    MetaData* evac_obj_meta = (MetaData*)((char*)evac_obj_data - sizeof(MetaData));
+    Object* evac_obj_data = (Object*)(OBJ_START_FROM_BLOCK(evac_obj_base));
+    MetaData* evac_obj_meta = META_FROM_OBJECT(evac_obj_data);
     
     // Insert evacuated object into forward table and set index in meta
     evac_obj_meta->forward_index = forward_table->size;
     add_to_worklist(forward_table, evac_obj_data);
 
     // Update the freelist of the original page to point to the newly freed block
-    FreeListEntry* new_freelist_entry = (FreeListEntry*)((char*)obj - sizeof(MetaData) - ALLOC_DEBUG_CANARY_SIZE);
+    // I suspect I could handle this freelist stuff within my rebuild freelist method.
+    FreeListEntry* new_freelist_entry = (FreeListEntry*)(BLOCK_START_FROM_OBJ(obj));
     new_freelist_entry->next = bin->freelist;
     bin->freelist = new_freelist_entry;
 
@@ -215,6 +156,14 @@ static void* evacuate_object(AllocatorBin *bin, Object* obj, Worklist* forward_t
     RESET_METADATA_FOR_OBJECT(old_metadata);
 
     return evac_obj_data;
+}
+
+/* Helper to update an objects children pointers */
+void update_children_pointers(Object* obj, Worklist* worklist, Worklist* forward_table) {
+    for (int i = 0; i < obj->num_children; i++) {
+        Object* oldest = remove_oldest_from_worklist(worklist);
+        obj->children[i] = forward_table->data[META_FROM_OBJECT(oldest)->forward_index];
+    }
 }
 
 void evacuate(Worklist *marked_nodes_list, AllocatorBin *bin) {
@@ -234,22 +183,13 @@ void evacuate(Worklist *marked_nodes_list, AllocatorBin *bin) {
                 add_to_worklist(&worklist, (Object*)evacuate_object(bin, obj, forward_table));
             } else {
                 // If the object we are trying to evacuate has children we will first update its children pointers then evacuate.
-                for (int i = 0; i < obj->num_children; i++) {
-                    // We want the OLDEST element in the worklist here -- not sure how to do so. It would also have to be removed.
-                    Object* oldest = remove_oldest_from_worklist(&worklist);
-                    obj->children[i] = forward_table->data[META_FROM_OBJECT(oldest)->forward_index];
-                }
+                update_children_pointers(obj, &worklist, forward_table);
                 add_to_worklist(&worklist, (Object*)evacuate_object(bin, obj, forward_table));
             }
         } else{
-            Object* root = remove_oldest_from_worklist(&worklist);
-            MetaData* root_meta = META_FROM_OBJECT(root);
-
             // If the object we are trying to evacuate has children we will first update its children pointers then evacuate.
-            for (int i = 0; i < obj->num_children; i++) {
-                obj->children[i] = forward_table->data[root_meta->forward_index];
-            }
-            add_to_worklist(&worklist, obj);
+            update_children_pointers(obj, &worklist, forward_table);
+            add_to_worklist(&worklist, obj); //Difference is we dont evac a root
         }
     }
 }
@@ -259,7 +199,7 @@ void rebuild_freelist(PageInfo* page) {
     page->freecount = 0;
 
     for(size_t i = 0; i < page->entrycount; i++) {
-        FreeListEntry* new_freelist_entry = (FreeListEntry*)((char*)page + sizeof(PageInfo) + (i * REAL_ENTRY_SIZE(page->entrysize)));
+        FreeListEntry* new_freelist_entry = (FreeListEntry*)(PAGE_OFFSET(page) + (i * REAL_ENTRY_SIZE(page->entrysize)));
         MetaData* meta = (MetaData*)((char*)new_freelist_entry + ALLOC_DEBUG_CANARY_SIZE);
 
         if(meta->isalloc == false) {
@@ -271,13 +211,13 @@ void rebuild_freelist(PageInfo* page) {
     }
 }
 
-// Just run through all pages and flag nodes that arent marked as non allocated
+// Just run through all pages and flag nodes that arent marked as non allocated --- may not be necessary
 void clean_nonref_nodes() {
     PageInfo* current_page = p_mgr.all_pages;
 
     while(current_page != NULL) {
         for(uint16_t i = 0; i < current_page->entrycount; i++) {
-            Object* current_object = (Object*)((char*)current_page + sizeof(PageInfo) + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) +
+            Object* current_object = (Object*)(PAGE_OFFSET(current_page) + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) +
                 (i * REAL_ENTRY_SIZE(current_page->entrysize)));
             MetaData* current_object_meta = META_FROM_OBJECT(current_object);
 
@@ -350,76 +290,4 @@ void mark_from_roots()
     evacuate(&marked_nodes_list, &a_bin);
 
     clean_nonref_nodes();
-}
-
-bool verifyCanariesInBlock(char* block, uint16_t entry_size)
-{
-    uint64_t* pre_canary = (uint64_t*)(block);
-    uint64_t* post_canary = (uint64_t*)(block + ALLOC_DEBUG_CANARY_SIZE + sizeof(MetaData) + entry_size);
-
-    if (*pre_canary != ALLOC_DEBUG_CANARY_VALUE || *post_canary != ALLOC_DEBUG_CANARY_VALUE)
-    {
-        debug_print("[ERROR] Canary corrupted at block %p\n", (void*)block);
-        debug_print("Data in pre-canary: %lx, data in post-canary: %lx\n", *pre_canary, *post_canary);
-        return false;
-    }
-    return true;
-}
-
-void verifyCanariesInPage(PageInfo* page)
-{
-    FreeListEntry* list = page->freelist;
-    char* base_address = (char*)page + sizeof(PageInfo);
-    uint16_t alloced_blocks = 0;
-    uint16_t free_blocks = 0;
-
-    for (uint16_t i = 0; i < page->entrycount; i++) {
-        char* block_address = base_address + (i * REAL_ENTRY_SIZE(page->entrysize));
-        debug_print("Checking block: %p\n", block_address);
-        MetaData* metadata = (MetaData*)(block_address + ALLOC_DEBUG_CANARY_SIZE);
-        debug_print("Metadata state: isalloc=%d\n", metadata->isalloc);
-
-        if (metadata->isalloc) {
-            alloced_blocks++;
-            assert(verifyCanariesInBlock(block_address, page->entrysize));
-        }
-    }
-
-    debug_print("\n");
-
-    while(list){
-        debug_print("Checking freelist block: %p\n", (void*)list);
-        MetaData* metadata = (MetaData*)((char*)list + ALLOC_DEBUG_CANARY_SIZE);
-        debug_print("Metadata state: isalloc=%d\n", metadata->isalloc);
-        if(metadata->isalloc){
-            debug_print("[ERROR] Block in free list was allocated\n");
-            assert(0);
-        }
-        free_blocks++;
-        list = list->next;
-    }   
-
-    // Make sure no blocks are lost
-    assert((free_blocks + alloced_blocks) == page->entrycount);
-
-    debug_print("\n");
-}
-
-void verifyAllCanaries(AllocatorBin* bin)
-{
-    PageInfo* current_page = bin->page_manager->all_pages;
-    PageInfo* evac_page = bin->page_manager->evacuate_page;
-
-    while (current_page) {
-        debug_print("PageManager all_pages head address: %p\n", current_page);
-        verifyCanariesInPage(current_page);
-        current_page = current_page->next;
-    }
-
-    while (evac_page) {
-        debug_print("PageManager evac_page head address: %p\n", evac_page);
-        verifyCanariesInPage(evac_page);
-        evac_page = evac_page->next;
-    }
-
 }

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -100,6 +100,7 @@ typedef struct {
     Object* data[WORKLIST_CAPACITY];
     size_t size;
 } Worklist;
+extern Worklist f_table;
 
 extern Object* root_stack[MAX_ROOTS];
 extern size_t root_count;

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -126,7 +126,7 @@ void evacuate(Worklist* marked_nodes_list, AllocatorBin* bin);
 /**
  * Process all objects starting from roots in BFS manner
  **/
-void mark_from_roots();
+void mark_from_roots(AllocatorBin* bin);
 
 /**
  * Slow path for usage with canaries --- debug
@@ -158,14 +158,6 @@ static inline void* allocate(AllocatorBin* alloc, MetaData* metadata)
 
     FreeListEntry* ret = alloc->freelist;
     alloc->freelist = ret->next;
-
-    /**
-    * Need to investigate further why our freelist for the current page does not update
-    * when we move the freelist pointer in our allocator. They are directly assigned
-    * so I am not completly sure why this is the case. alloc->freelist is just a pointer
-    * to the current pages freelist. Maybe make it the address of our pages freelist?
-    **/
-    alloc->page->freelist = ret->next;
 
     void* obj;
 

--- a/src/runtime/memory/allocator.h
+++ b/src/runtime/memory/allocator.h
@@ -6,10 +6,7 @@
 #include <stdio.h> //printf
 #endif
 
-#ifdef BSQ_GC_CHECK_ENABLED
-#define ALLOC_DEBUG_MEM_INITIALIZE
-#define ALLOC_DEBUG_CANARY
-#endif
+#include <string.h> //memcpy
 
 //Can also use other values like 0xFFFFFFFFFFFFFFFFul
 #define ALLOC_DEBUG_MEM_INITIALIZE_VALUE 0x0ul
@@ -35,13 +32,13 @@
 #define MEM_STATS_ARG(X)
 #endif
 
-#define SETUP_META_FLAGS(meta)           \
-do {                                     \
-    (*meta)->isalloc = true;             \
-    (*meta)->isyoung = true;             \
-    (*meta)->ismarked = false;           \
-    (*meta)->isroot = false;             \
-    (*meta)->forward_index = UINT32_MAX; \
+#define SETUP_META_FLAGS(meta)              \
+do {                                        \
+    (*meta)->isalloc = true;                \
+    (*meta)->isyoung = true;                \
+    (*meta)->ismarked = false;              \
+    (*meta)->isroot = false;                \
+    (*meta)->forward_index = MAX_FWD_INDEX; \
 } while(0)
 
 ////////////////////////////////
@@ -134,11 +131,10 @@ PageManager* initializePageManager(uint16_t entry_size);
  * over to our evacuate page(s). Traverse this list, move nodes, update
  * pointers from their parents.
  **/
-void evacuate(Worklist* marked_nodes_list); 
+void evacuate(Worklist* marked_nodes_list, AllocatorBin* bin); 
 
 /**
- * Method(s) for iterating through the root stack and marking all elements
- * inside said stack.
+ * Process all objects starting from roots in BFS manner
  **/
 void mark_from_roots();
 

--- a/src/runtime/worklist.h
+++ b/src/runtime/worklist.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "common.h"
+#include <stdio.h>
+
+/* This queue size will need to be tinkered with */
+#define WORKLIST_CAPACITY 1024
+
+typedef struct {
+    Object* data[WORKLIST_CAPACITY];
+    size_t size;
+} Worklist;
+
+/* Worklist helpers */
+static inline void initialize_worklist(Worklist* worklist) 
+{
+    worklist->size = 0;
+}
+
+static inline bool add_to_worklist(Worklist* worklist, Object* obj) 
+{
+    if (worklist->size >= WORKLIST_CAPACITY) {
+        /* Worklist is full */
+        debug_print("Worklist overflow!\n");
+        return false;
+    }
+    worklist->data[worklist->size++] = obj;
+    return true;
+}
+
+static inline Object* remove_from_worklist(Worklist* worklist) 
+{
+    if (worklist->size == 0) {
+        return NULL;
+    }
+    return worklist->data[--worklist->size]; //prefix decrement crucial here
+}
+
+/** 
+* This shifts the entire worklist which I do not like. 
+* There is 100% a better way to handle the work lists, but while in early dev
+* stages it gets the job done.
+**/
+static inline Object* remove_oldest_from_worklist(Worklist* worklist) {
+    if (worklist->size == 0) {
+        return NULL;
+    }
+    
+    Object* oldest = worklist->data[0];
+    
+    // Shift all elements to the left
+    for (size_t i = 1; i < worklist->size; i++) {
+        worklist->data[i - 1] = worklist->data[i];
+    }
+    
+    worklist->size--;
+    return oldest;
+}
+
+static inline bool is_worklist_empty(Worklist* worklist) 
+{
+    return worklist->size == 0;
+}

--- a/test/test.c
+++ b/test/test.c
@@ -118,13 +118,13 @@ void assert_all_marked(Object* obj) {
     }
 }
 
-void test_mark_single_object(AllocatorBin* bin, PageManager* pm) 
+void test_mark_single_object(AllocatorBin* bin) 
 {
     Object* obj = create_root(bin);
 
     Object* child = create_child(bin, obj);
 
-    mark_from_roots();
+    mark_from_roots(bin);
 
     assert_all_marked(obj);
 
@@ -136,7 +136,7 @@ void test_mark_single_object(AllocatorBin* bin, PageManager* pm)
     debug_print("Test Case 1 Passed: Single object marked successfully.\n\n");
 }
 
-void test_mark_object_graph(AllocatorBin *bin, PageManager *pm)
+void test_mark_object_graph(AllocatorBin *bin)
 {
     Object* obj1 = create_root(bin);
     Object* obj2 = create_root(bin);
@@ -158,7 +158,7 @@ void test_mark_object_graph(AllocatorBin *bin, PageManager *pm)
     Object* random_unmarked_child = create_child(bin, random_unmarked_obj);
     MetaData* rdm_md = META_FROM_OBJECT(random_unmarked_obj);
 
-    mark_from_roots();
+    mark_from_roots(bin);
 
     assert_all_marked(obj1);
     assert_all_marked(obj2);
@@ -170,7 +170,7 @@ void test_mark_object_graph(AllocatorBin *bin, PageManager *pm)
     debug_print("Test Case 2 Passed: Object graph marked successfully.\n\n");
 }
 
-void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm)
+void test_mark_cyclic_graph(AllocatorBin* bin)
 {
     Object* obj1 = create_root(bin);
     Object* obj2 = create_root(bin);
@@ -204,7 +204,7 @@ void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm)
     Object* random_unmarked_child = create_child(bin, random_unmarked_obj);
     MetaData* rdm_md = META_FROM_OBJECT(random_unmarked_obj);
 
-    mark_from_roots();
+    mark_from_roots(bin);
 
     assert(META_FROM_OBJECT(obj1)->ismarked == true);
     assert(META_FROM_OBJECT(obj2)->ismarked == true);
@@ -222,7 +222,7 @@ void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm)
     debug_print("Test Case 3 Passed: Object graph with cycles marked correctly.\n");
 }
 
-void test_canary_failure(AllocatorBin *bin, PageManager *pm)
+void test_canary_failure(AllocatorBin *bin)
 {
     uint64_t* canary_cobber = (uint64_t*)allocate(bin, NULL);
 
@@ -232,9 +232,9 @@ void test_canary_failure(AllocatorBin *bin, PageManager *pm)
     canary_cobber[-3] = 0xBADBADBADBADBADB;
 }
 
-void test_evacuation(AllocatorBin* bin, PageManager* pm) {
-    PageInfo* cur_alloc_page = pm->all_pages;
-    PageInfo* cur_evac_page = pm->evacuate_page;
+void test_evacuation(AllocatorBin* bin) {
+    PageInfo* cur_alloc_page = bin->page_manager->all_pages;
+    PageInfo* cur_evac_page = bin->page_manager->evacuate_page;
 
     // Lets make sure only roots are in our allocate pages
     while(cur_alloc_page) {
@@ -295,13 +295,12 @@ void test_evacuation(AllocatorBin* bin, PageManager* pm) {
 
 void run_tests()
 {
-    PageManager* pm = initializePageManager(DEFAULT_ENTRY_SIZE);
     AllocatorBin* bin = initializeAllocatorBin(DEFAULT_ENTRY_SIZE);
-    test_mark_single_object(bin, pm);
-    test_mark_object_graph(bin, pm);
-    ///test_mark_cyclic_graph(bin, pm);
-    //test_canary_failure(bin,  pm);
-    test_evacuation(bin, pm);
+    test_mark_single_object(bin);
+    test_mark_object_graph(bin);
+    ///test_mark_cyclic_graph(bin);
+    //test_canary_failure(bin);
+    test_evacuation(bin);
 
     verifyAllCanaries(bin);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -223,7 +223,7 @@ void run_tests()
     test_mark_object_graph(bin, pm);
     test_mark_cyclic_graph(bin, pm);
     test_canary_failure(bin,  pm);
-    test_evacuation(bin, pm);
+    //test_evacuation(bin, pm);
 
     verifyAllCanaries(bin);
 }

--- a/test/test.c
+++ b/test/test.c
@@ -80,6 +80,8 @@ void test_mark_object_graph(AllocatorBin *bin, PageManager *pm)
     create_child(bin, child3);
 
     Object* random_unmarked_obj = (Object*)allocate(bin, NULL);
+    debug_print("[DEBUG] Created non root random object at %p\n", random_unmarked_obj);
+    
     Object* random_unmarked_child = create_child(bin, random_unmarked_obj);
     MetaData* rdm_md = META_FROM_OBJECT(random_unmarked_obj);
 

--- a/test/test.c
+++ b/test/test.c
@@ -15,6 +15,8 @@ void* create_root(AllocatorBin* bin)
         }
     }
 
+    metadata->isroot = true;
+
     return (void*)obj; //maybe no need for void*?
 }
 

--- a/test/test.h
+++ b/test/test.h
@@ -5,11 +5,11 @@
 /**
  * Our varrying tests for properly marking objects 
  **/
-void test_mark_single_object(AllocatorBin* bin, PageManager* pm);
-void test_mark_object_graph(AllocatorBin* bin, PageManager* pm);
-void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm);
-void test_canary_failure(AllocatorBin* bin, PageManager* pm);
-void test_evacuation(AllocatorBin* bin, PageManager* pm);
+void test_mark_single_object(AllocatorBin* bin);
+void test_mark_object_graph(AllocatorBin* bin);
+void test_mark_cyclic_graph(AllocatorBin* bin);
+void test_canary_failure(AllocatorBin* bin);
+void test_evacuation(AllocatorBin* bin);
 
 /**
  * Traverse pages and freelists ensuring no canaries are clobbered and that

--- a/test/test.h
+++ b/test/test.h
@@ -9,6 +9,7 @@ void test_mark_single_object(AllocatorBin* bin, PageManager* pm);
 void test_mark_object_graph(AllocatorBin* bin, PageManager* pm);
 void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm);
 void test_canary_failure(AllocatorBin* bin, PageManager* pm);
+void test_evacuation(AllocatorBin* bin, PageManager* pm);
 
 /**  
 * Lets add some more tests for lots of roots spanning multiple pages with (max?) children,

--- a/test/test.h
+++ b/test/test.h
@@ -6,8 +6,7 @@
  * Our varrying tests for properly marking objects 
  **/
 void test_mark_single_object(AllocatorBin* bin);
-void test_mark_object_graph(AllocatorBin* bin);
-void test_mark_cyclic_graph(AllocatorBin* bin);
+void test_mark_object_graph(AllocatorBin *bin, int num_roots, int num_children_per_node, int max_depth);
 void test_canary_failure(AllocatorBin* bin);
 void test_evacuation(AllocatorBin* bin);
 

--- a/test/test.h
+++ b/test/test.h
@@ -11,10 +11,15 @@ void test_mark_cyclic_graph(AllocatorBin* bin, PageManager* pm);
 void test_canary_failure(AllocatorBin* bin, PageManager* pm);
 void test_evacuation(AllocatorBin* bin, PageManager* pm);
 
-/**  
-* Lets add some more tests for lots of roots spanning multiple pages with (max?) children,
-* the introduction of cycles, and lots of objects not conntected to a root!
-**/
+/**
+ * Traverse pages and freelists ensuring no canaries are clobbered and that
+ * our freelists contain no already allocated objects.
+ **/
+#ifdef ALLOC_DEBUG_CANARY
+void verifyAllCanaries(AllocatorBin* bin);
+void verifyCanariesInPage(PageInfo* page);
+bool verifyCanariesInBlock(char* block, uint16_t entry_size);
+#endif
 
 /**
  * Run all tests together


### PR DESCRIPTION
- Marking now correctly returns BFS list of all marked nodes
- Evacuated nodes are moved to new evacuation_page
- Integrity of free list and page state verified after evacuation
- Freelist gets rebuilt after moving to evac page
- Refactoring

There are some changes I made which I am not too big a fan of. And there are still issues related to changes in page manager not reflecting in allocator bin that I just haven't been able to determine the cause of. Needs some more investigation, but the code as is has the meat of what needs to be present to properly mark and evacuate nodes, then update their pages so the blocks that were just moved are considered free.